### PR TITLE
Use `bytemuck` for "safe" type casting.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -21,6 +21,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "37ccbd214614c6783386c1af30caf03192f17891059cecc394b4fb119e363de3"
 
 [[package]]
+name = "bytemuck"
+version = "1.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "17febce684fd15d89027105661fec94afb475cb995fbc59d2865198446ba2eea"
+
+[[package]]
 name = "byteorder"
 version = "1.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -433,6 +439,7 @@ dependencies = [
 name = "minifb-demo"
 version = "0.1.0"
 dependencies = [
+ "bytemuck",
  "minifb",
  "plotters",
  "plotters-bitmap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,6 +7,7 @@ edition = "2018"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
+bytemuck = "1.13"
 minifb = "0.23.0"
 
 [dependencies.plotters]

--- a/src/main.rs
+++ b/src/main.rs
@@ -6,6 +6,7 @@ use std::collections::VecDeque;
 use std::error::Error;
 use std::time::SystemTime;
 use std::borrow::{Borrow, BorrowMut};
+
 const W: usize = 800;
 const H: usize = 600;
 
@@ -13,35 +14,25 @@ const SAMPLE_RATE: f64 = 10_000.0;
 const FRAME_RATE: f64 = 30.0;
 
 struct BufferWrapper(Vec<u32>);
+
 impl Borrow<[u8]> for BufferWrapper {
     fn borrow(&self) -> &[u8] {
-        // Safe for alignment: align_of(u8) <= align_of(u32)
-        // Safe for cast: u32 can be thought of as being transparent over [u8; 4]
-        unsafe {
-            std::slice::from_raw_parts(
-                self.0.as_ptr() as *const u8,
-                self.0.len() * 4
-            )
-        }
+        bytemuck::cast_slice(&self.0)
     }
 }
+
 impl BorrowMut<[u8]> for BufferWrapper {
     fn borrow_mut(&mut self) -> &mut [u8] {
-        // Safe for alignment: align_of(u8) <= align_of(u32)
-        // Safe for cast: u32 can be thought of as being transparent over [u8; 4]
-        unsafe {
-            std::slice::from_raw_parts_mut(
-                self.0.as_mut_ptr() as *mut u8,
-                self.0.len() * 4
-            )
-        }
+        bytemuck::cast_slice_mut(&mut self.0)
     }
 }
+
 impl Borrow<[u32]> for BufferWrapper {
     fn borrow(&self) -> &[u32] {
         self.0.as_slice()
     }
 }
+
 impl BorrowMut<[u32]> for BufferWrapper {
     fn borrow_mut(&mut self) -> &mut [u32] {
         self.0.as_mut_slice()


### PR DESCRIPTION
The [`bytemuck`](https://crates.io/crates/bytemuck) crate is [generally considered](https://blessed.rs/#section-common-subsection-lang-extensions) the best way to do "safe" type casting between different primitive types. I'm sure this solution compiles into the same exact thing, but I think using `bytemuck` over `slice::from_raw_parts_*` sets a safer example in demo files which are often blindly copied by beginners.

If this feels too pedantic, feel free to close it 👍🏽.